### PR TITLE
Take project references into account

### DIFF
--- a/Inedo.DependencyScan/DependencyScanner.cs
+++ b/Inedo.DependencyScan/DependencyScanner.cs
@@ -51,7 +51,7 @@ namespace Inedo.DependencyScan
         /// <param name="considerProjectReferences">Determines if project references are considered as package references or not (only relevant for NuGetDependencyScanner).</param>
         /// <param name="cancellationToken">Cancellation token for asynchronous operation.</param>
         /// <returns>Dependencies used by each project.</returns>
-        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences, CancellationToken cancellationToken = default);
+        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a <see cref="DependencyScanner"/> for the specified path.

--- a/Inedo.DependencyScan/DependencyScanner.cs
+++ b/Inedo.DependencyScan/DependencyScanner.cs
@@ -48,9 +48,10 @@ namespace Inedo.DependencyScan
         /// <summary>
         /// Returns the dependencies used by each project in the specified <see cref="SourcePath"/>.
         /// </summary>
+        /// <param name="considerProjectReferences">Determines if project references are considered as package references or not.</param>
         /// <param name="cancellationToken">Cancellation token for asynchronous operation.</param>
         /// <returns>Dependencies used by each project.</returns>
-        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default);
+        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a <see cref="DependencyScanner"/> for the specified path.

--- a/Inedo.DependencyScan/DependencyScanner.cs
+++ b/Inedo.DependencyScan/DependencyScanner.cs
@@ -48,7 +48,7 @@ namespace Inedo.DependencyScan
         /// <summary>
         /// Returns the dependencies used by each project in the specified <see cref="SourcePath"/>.
         /// </summary>
-        /// <param name="considerProjectReferences">Determines if project references are considered as package references or not.</param>
+        /// <param name="considerProjectReferences">Determines if project references are considered as package references or not (only relevant for NuGetDependencyScanner).</param>
         /// <param name="cancellationToken">Cancellation token for asynchronous operation.</param>
         /// <returns>Dependencies used by each project.</returns>
         public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences, CancellationToken cancellationToken = default);

--- a/Inedo.DependencyScan/NpmDependencyScanner.cs
+++ b/Inedo.DependencyScan/NpmDependencyScanner.cs
@@ -17,7 +17,7 @@ namespace Inedo.DependencyScan
         public override DependencyScannerType Type => DependencyScannerType.Npm;
 
 #if !NET452
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, CancellationToken cancellationToken = default)
         {
             var packageLockPath = this.FileSystem.Combine(this.FileSystem.GetDirectoryName(this.SourcePath), "package-lock.json");
 
@@ -44,7 +44,7 @@ namespace Inedo.DependencyScan
             }
         }
 #else
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, CancellationToken cancellationToken = default)
         {
             var packageLockPath = this.FileSystem.Combine(this.FileSystem.GetDirectoryName(this.SourcePath), "package-lock.json");
 

--- a/Inedo.DependencyScan/NuGetDependencyScanner.cs
+++ b/Inedo.DependencyScan/NuGetDependencyScanner.cs
@@ -22,7 +22,7 @@ namespace Inedo.DependencyScan
 
         public override DependencyScannerType Type => DependencyScannerType.NuGet;
 
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences, CancellationToken cancellationToken = default)
         {
             if (this.SourcePath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
             {
@@ -33,7 +33,7 @@ namespace Inedo.DependencyScan
                 foreach (var p in await ReadProjectsFromSolutionAsync(this.SourcePath, cancellationToken).ConfigureAwait(false))
                 {
                     var projectPath = this.FileSystem.Combine(solutionRoot, p);
-                    projects.Add(new ScannedProject(this.FileSystem.GetFileNameWithoutExtension(p), await ReadProjectDependenciesAsync(projectPath, cancellationToken).ConfigureAwait(false)));
+                    projects.Add(new ScannedProject(this.FileSystem.GetFileNameWithoutExtension(p), await ReadProjectDependenciesAsync(projectPath, considerProjectReferences, cancellationToken).ConfigureAwait(false)));
                 }
 
                 return projects;
@@ -42,7 +42,7 @@ namespace Inedo.DependencyScan
             {
                 return new[]
                 {
-                    new ScannedProject(this.FileSystem.GetFileNameWithoutExtension(this.SourcePath), await ReadProjectDependenciesAsync(this.SourcePath, cancellationToken).ConfigureAwait(false))
+                    new ScannedProject(this.FileSystem.GetFileNameWithoutExtension(this.SourcePath), await ReadProjectDependenciesAsync(this.SourcePath, considerProjectReferences, cancellationToken).ConfigureAwait(false))
                 };
             }
         }
@@ -55,7 +55,7 @@ namespace Inedo.DependencyScan
                 .Select(m => m.Groups[1].Value);
         }
 
-        private async Task<IEnumerable<DependencyPackage>> ReadProjectDependenciesAsync(string projectPath, CancellationToken cancellationToken)
+        private async Task<IEnumerable<DependencyPackage>> ReadProjectDependenciesAsync(string projectPath, bool considerProjectReferences, CancellationToken cancellationToken)
         {
             var projectDir = this.FileSystem.GetDirectoryName(projectPath);
             var packagesConfigPath = this.FileSystem.Combine(projectDir, "packages.config");
@@ -64,7 +64,7 @@ namespace Inedo.DependencyScan
 
             var assetsPath = this.FileSystem.Combine(this.FileSystem.Combine(projectDir, "obj"), "project.assets.json");
             if (await this.FileSystem.FileExistsAsync(assetsPath, cancellationToken).ConfigureAwait(false))
-                return await ReadProjectAssetsAsync(assetsPath, cancellationToken).ConfigureAwait(false);
+                return await ReadProjectAssetsAsync(assetsPath, considerProjectReferences, cancellationToken).ConfigureAwait(false);
 
             return Enumerable.Empty<DependencyPackage>();
         }
@@ -92,7 +92,7 @@ namespace Inedo.DependencyScan
         }
 
 #if !NET452
-        private async Task<IEnumerable<DependencyPackage>> ReadProjectAssetsAsync(string projectAssetsPath, CancellationToken cancellationToken)
+        private async Task<IEnumerable<DependencyPackage>> ReadProjectAssetsAsync(string projectAssetsPath, bool considerProjectReferences, CancellationToken cancellationToken)
         {
             JsonDocument jdoc;
             using (var stream = await this.FileSystem.OpenReadAsync(projectAssetsPath, cancellationToken).ConfigureAwait(false))
@@ -100,16 +100,16 @@ namespace Inedo.DependencyScan
                 jdoc = JsonDocument.Parse(stream);
             }
 
-            return enumeratePackages(jdoc);
+            return enumeratePackages(jdoc, considerProjectReferences);
 
-            static IEnumerable<DependencyPackage> enumeratePackages(JsonDocument jdoc)
+            static IEnumerable<DependencyPackage> enumeratePackages(JsonDocument jdoc, bool considerProjectReferences)
             {
                 var libraries = jdoc.RootElement.GetProperty("libraries");
                 if (libraries.ValueKind == JsonValueKind.Object)
                 {
                     foreach (var library in libraries.EnumerateObject())
                     {
-                        if (library.Value.GetProperty("type").ValueEquals("package"))
+                        if (library.Value.GetProperty("type").ValueEquals("package") || (library.Value.GetProperty("type").ValueEquals("project") && considerProjectReferences))
                         {
                             var parts = library.Name.Split(new[] { '/' }, 2);
 
@@ -124,7 +124,7 @@ namespace Inedo.DependencyScan
             }
         }
 #else
-        private async Task<IEnumerable<DependencyPackage>> ReadProjectAssetsAsync(string projectAssetsPath, CancellationToken cancellationToken)
+        private async Task<IEnumerable<DependencyPackage>> ReadProjectAssetsAsync(string projectAssetsPath, bool considerProjectReferences, CancellationToken cancellationToken)
         {
             JObject jdoc;
             using (var reader = new JsonTextReader(new StreamReader(await this.FileSystem.OpenReadAsync(projectAssetsPath, cancellationToken).ConfigureAwait(false), Encoding.UTF8)))
@@ -132,15 +132,15 @@ namespace Inedo.DependencyScan
                 jdoc = JObject.Load(reader);
             }
 
-            return enumeratePackages(jdoc);
+            return enumeratePackages(jdoc, considerProjectReferences);
 
-            static IEnumerable<DependencyPackage> enumeratePackages(JObject jdoc)
+            static IEnumerable<DependencyPackage> enumeratePackages(JObject jdoc, bool considerProjectReferences)
             {
                 if (jdoc["libraries"] is JObject libraries)
                 {
                     foreach (var library in libraries.Properties())
                     {
-                        if ((string)((JObject)library.Value).Property("type") == "package")
+                        if ((string)((JObject)library.Value).Property("type") == "package" || ((string)((JObject)library.Value).Property("type") == "project" && considerProjectReferences))
                         {
                             var parts = library.Name.Split(new[] { '/' }, 2);
     

--- a/Inedo.DependencyScan/NuGetDependencyScanner.cs
+++ b/Inedo.DependencyScan/NuGetDependencyScanner.cs
@@ -22,7 +22,7 @@ namespace Inedo.DependencyScan
 
         public override DependencyScannerType Type => DependencyScannerType.NuGet;
 
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, CancellationToken cancellationToken = default)
         {
             if (this.SourcePath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
             {

--- a/Inedo.DependencyScan/PypiDependencyScanner.cs
+++ b/Inedo.DependencyScan/PypiDependencyScanner.cs
@@ -9,7 +9,7 @@ namespace Inedo.DependencyScan
     {
         public override DependencyScannerType Type => DependencyScannerType.PyPI;
 
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, CancellationToken cancellationToken = default)
         {
             return new[] { new ScannedProject("PyPiPackage", await this.ReadDependenciesAsync(cancellationToken).ConfigureAwait(false)) };
         }

--- a/PgScanCommon/Program.cs
+++ b/PgScanCommon/Program.cs
@@ -73,8 +73,10 @@ namespace Inedo.DependencyScan
             if (!Enum.TryParse<DependencyScannerType>(typeName, true, out var type))
                 throw new PgScanException($"Invalid scanner type: {typeName} (must be nuget, npm, or pypi)");
 
+            args.Named.TryGetValue("consider-project-references", out var considerProjectReferences);
+
             var scanner = DependencyScanner.GetScanner(inputFileName, type);
-            var projects = await scanner.ResolveDependenciesAsync();
+            var projects = await scanner.ResolveDependenciesAsync(considerProjectReferences is null ? false : true);
             if (projects.Count > 0)
             {
                 foreach (var p in projects)
@@ -144,8 +146,6 @@ namespace Inedo.DependencyScan
                 consumerName = consumerPackageName;
             }
 
-
-
             string consumerFeed = null;
             string consumerUrl = null;
 
@@ -154,8 +154,10 @@ namespace Inedo.DependencyScan
             else
                 consumerFeed = consumerSource;
 
+            args.Named.TryGetValue("consider-project-references", out var considerProjectReferences);
+
             var scanner = DependencyScanner.GetScanner(inputFileName, type);
-            var projects = await scanner.ResolveDependenciesAsync();
+            var projects = await scanner.ResolveDependenciesAsync(considerProjectReferences is null ? false : true);
 
 
             if (string.IsNullOrEmpty(consumerName))
@@ -244,6 +246,7 @@ namespace Inedo.DependencyScan
             Console.WriteLine("  --consumer-package-group=<group>");
             Console.WriteLine("  --consumer-package-file=<file name to read package name and version from (e.g. a dll or exe)>");
             Console.WriteLine("  --api-key=<ProGet API key>");
+            Console.WriteLine("  --consider-project-references=<treat project references as package references>");
             Console.WriteLine();
             Console.WriteLine("Commands:");
             Console.WriteLine("  report\tDisplay dependency data");

--- a/PgScanCommon/Program.cs
+++ b/PgScanCommon/Program.cs
@@ -74,6 +74,8 @@ namespace Inedo.DependencyScan
                 throw new PgScanException($"Invalid scanner type: {typeName} (must be nuget, npm, or pypi)");
 
             args.Named.TryGetValue("consider-project-references", out var considerProjectReferences);
+            if (!string.IsNullOrEmpty(considerProjectReferences))
+                throw new PgScanException("Supplying a value for option --consider-project-references is not allowed.");
 
             var scanner = DependencyScanner.GetScanner(inputFileName, type);
             var projects = await scanner.ResolveDependenciesAsync(considerProjectReferences is null ? false : true);
@@ -155,9 +157,11 @@ namespace Inedo.DependencyScan
                 consumerFeed = consumerSource;
 
             args.Named.TryGetValue("consider-project-references", out var considerProjectReferences);
+            if (!string.IsNullOrEmpty(considerProjectReferences))
+                throw new PgScanException("Supplying a value for option --consider-project-references is not allowed.");
 
             var scanner = DependencyScanner.GetScanner(inputFileName, type);
-            var projects = await scanner.ResolveDependenciesAsync(considerProjectReferences is null ? false : true);
+            var projects = await scanner.ResolveDependenciesAsync(considerProjectReferences == null ? false : true);
 
 
             if (string.IsNullOrEmpty(consumerName))
@@ -246,7 +250,7 @@ namespace Inedo.DependencyScan
             Console.WriteLine("  --consumer-package-group=<group>");
             Console.WriteLine("  --consumer-package-file=<file name to read package name and version from (e.g. a dll or exe)>");
             Console.WriteLine("  --api-key=<ProGet API key>");
-            Console.WriteLine("  --consider-project-references=<treat project references as package references>");
+            Console.WriteLine("  --consider-project-references (treat project references as package references)");
             Console.WriteLine();
             Console.WriteLine("Commands:");
             Console.WriteLine("  report\tDisplay dependency data");


### PR DESCRIPTION
Added a switch to consider references of type 'project' from the project.assets.json.
(Based on issue #7).