### PR TITLE
Added support for Solution Folders (issue #28) and some refactoring

### DIFF
--- a/Inedo.DependencyScan/DependencyScanner.cs
+++ b/Inedo.DependencyScan/DependencyScanner.cs
@@ -49,11 +49,9 @@ namespace Inedo.DependencyScan
         /// <summary>
         /// Returns the dependencies used by each project in the specified <see cref="SourcePath"/>.
         /// </summary>
-        /// <param name="considerProjectReferences">Determines if project references are considered as package references or not (only relevant for NuGetDependencyScanner).</param>
-        /// <param name="scanForChildNpmDependencies">Determines if the scanner should look for child package-lock.json files for npm dependencies or not.</param>
         /// <param name="cancellationToken">Cancellation token for asynchronous operation.</param>
         /// <returns>Dependencies used by each project.</returns>
-        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, bool scanForChildNpmDependencies = true, CancellationToken cancellationToken = default);
+        public abstract Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a <see cref="DependencyScanner"/> for the specified path.

--- a/Inedo.DependencyScan/IConfigurableDependencyScanner.cs
+++ b/Inedo.DependencyScan/IConfigurableDependencyScanner.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace Inedo.DependencyScan
+{
+    /// <summary>
+    /// Interface to make certain methods publicly visible that are not implemented by all implementations of DependencyScanner
+    /// </summary>
+    public interface IConfigurableDependencyScanner
+    {
+        #region Public Methods
+        /// <summary>
+        /// Sets arguments provided command line
+        /// </summary>
+        /// <param name="namedArguments">The dictionary containing the named arguments</param>
+        void SetArgs(IReadOnlyDictionary<string, string> namedArguments);
+
+        #endregion Public Methods
+    }
+}

--- a/Inedo.DependencyScan/NpmDependencyScanner.cs
+++ b/Inedo.DependencyScan/NpmDependencyScanner.cs
@@ -9,7 +9,7 @@ namespace Inedo.DependencyScan
     {
         public override DependencyScannerType Type => DependencyScannerType.Npm;
 
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, bool scanForChildNpmDependencies = true, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
         {
             var packageLockPath = this.FileSystem.Combine(this.FileSystem.GetDirectoryName(this.SourcePath), "package-lock.json");
 

--- a/Inedo.DependencyScan/PypiDependencyScanner.cs
+++ b/Inedo.DependencyScan/PypiDependencyScanner.cs
@@ -10,7 +10,7 @@ namespace Inedo.DependencyScan
     {
         public override DependencyScannerType Type => DependencyScannerType.PyPI;
 
-        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(bool considerProjectReferences = false, bool scanForChildNpmDependencies = true, CancellationToken cancellationToken = default)
+        public override async Task<IReadOnlyCollection<ScannedProject>> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
         {
             return new[] { new ScannedProject("PyPiPackage", await this.ReadDependenciesAsync(cancellationToken).ToListAsync(cancellationToken).ConfigureAwait(false)) };
         }


### PR DESCRIPTION
This PR resolves issue #28 ("Support solution folders").
It also does some refactoring w.r.t. DependencyScanner.GetScanner and scanner.ResolveDependenciesAsync. Instead of adding yet another parameter to ResolveDependenciesAsync, we added the ability to pass arguments to the corresponding DependecyScanner implementations.