### PR TITLE
Support newer npm package-lock dependency format introduced with lockfileVersion 3

### DIFF
--- a/Inedo.DependencyScan/NpmDependencyScanner.cs
+++ b/Inedo.DependencyScan/NpmDependencyScanner.cs
@@ -57,6 +57,5 @@ namespace Inedo.DependencyScan
                 yield return new DependencyPackage { Name = name, Version = version, Type = "npm" };
             }
         }
-        }
     }
 }

--- a/Inedo.DependencyScan/NpmDependencyScanner.cs
+++ b/Inedo.DependencyScan/NpmDependencyScanner.cs
@@ -17,7 +17,7 @@ namespace Inedo.DependencyScan
             using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var projectName = doc.RootElement.GetProperty("name").GetString();
-            return new[] { new ScannedProject(projectName, ReadDependencies(doc)) };
+            return new[] { new ScannedProject(projectName, ReadDependencies(doc).Distinct()) };
         }
 
         private static IEnumerable<DependencyPackage> ReadDependencies(JsonDocument doc)


### PR DESCRIPTION
Add support for the new format introduced to package-lock.json files with lockfileVersion 3 support.

Addresses the functionality discussed in the [forum here](https://forums.inedo.com/topic/3877/pgscan-lockfileversion-3-for-npm-dependencies-not-supported/5), as well as in issues #33 and #34 

I have tested this locally targeting lockfileVersion 2 and lockfileVersion 3 package-lock.json files with success. I am happy to add any tests with some guidance as needed.