### PR TITLE
Improved support for package-lock.json (npm)

### DIFF
--- a/Inedo.DependencyScan/ProGetClient.cs
+++ b/Inedo.DependencyScan/ProGetClient.cs
@@ -80,10 +80,15 @@ namespace Inedo.DependencyScan
             using var bomWriter = new BomWriter(stream);
             bomWriter.Begin(consumer.Group, consumer.Name, consumer.Version, consumerType);
 
-            foreach (var p in projects)
+            // Iterate through depencies. Calling Distinct() eliminates duplictes.
+            // Ordering by group/name/version makes it easier to compare different sbom files.
+            foreach (var d in (projects.SelectMany(p => p.Dependencies))
+                .Distinct()
+                .OrderBy(d => d.Group)
+                .ThenBy(d => d.Name)
+                .ThenBy(d => d.Version))
             {
-                foreach (var d in p.Dependencies)
-                    bomWriter.AddPackage(d.Group, d.Name, d.Version, d.Type ?? packageType);
+                bomWriter.AddPackage(d.Group, d.Name, d.Version, d.Type ?? packageType);
             }
         }
 


### PR DESCRIPTION
This PR adds recursive calls to `ReadDependencies()` in `NpmDependencyScanner` to add sub-dependencies to the sbom file (file format version 1 and 2). Those had been missing so far when they were required in a different version.

It also checks for the `name` property when reading files of format version 2 or 3. If present, this property seems to contain a name alias (basically what the 'npm:' prefix did in the `version `property in the old format). 

This PR also adds a `Distinct()` to the project dependencies in `ProGetClient` before calling the `BomWriter`. This eliminates redundant entries in the sbom file (mainly for NuGet when a product consists of several csproj-files) and can significantly reduce its file size. In my test case an 8 MB file was reduced to approx. 70 KB!